### PR TITLE
Add restrictions to bots' positions

### DIFF
--- a/Assets/CollisionManager.cs
+++ b/Assets/CollisionManager.cs
@@ -4,6 +4,7 @@ using UnityStandardAssets.Characters.ThirdPerson;
 
 public class CollisionManager : MonoBehaviour {
 	private Vector3 m_Move;
+	private int WALL_LENGHT = 50;
 
 	void OnCollisionEnter (Collision col)
 	{
@@ -12,14 +13,30 @@ public class CollisionManager : MonoBehaviour {
 			ScoreManager.score += 10;
 
 			// Move the bot randomly
-			System.Random r = new System.Random ();
-			m_Move = new Vector3 (r.Next (5, 15) * 1.0f, 0.0f, r.Next (5, 15) * 1.0f);
-			col.gameObject.transform.position += m_Move;
+			MoveBot(col);
 		}
 		else if (col.collider.tag == "Fire")
 		{
 			ScoreManager.score -= 10;
 		}
+	}
+
+	void MoveBot(Collision bot) {
+		System.Random r = new System.Random ();
+		float x_change = r.Next (5, 15) * 1.0f;
+		float z_change = r.Next (5, 15) * 1.0f;
+		float current_x = bot.gameObject.transform.position.x;
+		float current_z = bot.gameObject.transform.position.z;
+
+		// Check map boundaries
+		if (current_x + x_change > WALL_LENGHT)
+			x_change *= -1.0f;
+		if (current_z + z_change > WALL_LENGHT)
+			z_change *= -1.0f;
+
+		Debug.Log ("X change: " + x_change + ", Z change: " + z_change);
+		m_Move = new Vector3 (x_change, 0.0f, z_change);
+		bot.gameObject.transform.position += m_Move;
 	}
 	
 }


### PR DESCRIPTION
Earlier on collision I was just moving bots randomly. However after adding boundary walls sometimes these random movements were pushing bots outside of those boundaries. Right now I added restrictions so as to move bots only inside those boundaries.
